### PR TITLE
Add precondition to prevent kubernetes patch versions in variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,15 @@ resource "azurerm_kubernetes_cluster" "this" {
     ignore_changes = [
       kubernetes_version
     ]
+
+    precondition {
+      condition     = var.kubernetes_version == null || try(can(regex("^[0-9]+\\.[0-9]+$", var.kubernetes_version)), false)
+      error_message = "Ensure that kubernetes_version does not specify a patch version"
+    }
+    precondition {
+      condition     = var.orchestrator_version == null || try(can(regex("^[0-9]+\\.[0-9]+$", var.orchestrator_version)), false)
+      error_message = "Ensure that orchestrator_version does not specify a patch version"
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,10 @@ resource "azurerm_kubernetes_cluster" "this" {
     tags                   = merge(var.tags, var.agents_tags)
     vnet_subnet_id         = module.vnet.vnet_subnets_name_id["nodecidr"]
     zones                  = try([for zone in local.regions_by_name_or_display_name[var.location].zones : zone], null)
+
+    upgrade_settings {
+      max_surge = "10%"
+    }
   }
   auto_scaler_profile {
     balance_similar_node_groups = true


### PR DESCRIPTION
## Description

Makes sure a patch version is not specified in kubernetes_version and orchestrator_version

Fixes #63 

