### PR TITLE
Add a precondition for nodepool names

### DIFF
--- a/examples/with_availability_zone/README.md
+++ b/examples/with_availability_zone/README.md
@@ -60,7 +60,7 @@ module "test" {
   location = "East US 2" # Hardcoded because we have to test in a region with availability zones
   node_pools = {
     workload = {
-      name                 = "workload"
+      name                 = "workloadworkload" #Long name to test the truncate to 12 characters
       vm_size              = "Standard_D2d_v5"
       orchestrator_version = "1.28"
       max_count            = 110

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -54,7 +54,7 @@ module "test" {
   location = "East US 2" # Hardcoded because we have to test in a region with availability zones
   node_pools = {
     workload = {
-      name                 = "workload"
+      name                 = "workloadworkload" #Long name to test the truncate to 12 characters
       vm_size              = "Standard_D2d_v5"
       orchestrator_version = "1.28"
       max_count            = 110

--- a/locals.tf
+++ b/locals.tf
@@ -35,7 +35,7 @@ locals {
     for pool in var.node_pools : [
       for zone in try(local.regions_by_name_or_display_name[var.location].zones, [""]) : {
         # concatenate name and zone trim to 12 characters
-        name                 = "${substr(pool.name, 0, 11)}${zone}"
+        name                 = "${substr(pool.name, 0, 10)}${zone}"
         vm_size              = pool.vm_size
         orchestrator_version = pool.orchestrator_version
         max_count            = pool.max_count

--- a/main.tf
+++ b/main.tf
@@ -226,7 +226,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   })
 
   kubernetes_cluster_id = azurerm_kubernetes_cluster.this.id
-  name                  = "np${each.value.name}"
+  name                  = each.value.name
   vm_size               = each.value.vm_size
   enable_auto_scaling   = true
   max_count             = each.value.max_count
@@ -238,6 +238,13 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   zones                 = each.value.zone == "" ? null : [each.value.zone]
 
   depends_on = [azapi_update_resource.aks_cluster_post_create]
+
+  lifecycle {
+    precondition {
+      condition     = can(regex("^[a-z][a-z0-9]{0,11}$", each.value.name))
+      error_message = "The name must begin with a lowercase letter, contain only lowercase letters and numbers, and be between 1 and 12 characters in length."
+    }
+  }
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,10 @@ resource "azurerm_kubernetes_cluster" "this" {
     tags                   = merge(var.tags, var.agents_tags)
     vnet_subnet_id         = module.vnet.vnet_subnets_name_id["nodecidr"]
     zones                  = try([for zone in local.regions_by_name_or_display_name[var.location].zones : zone], null)
+
+    upgrade_settings {
+      max_surge = "10%"
+    }
   }
   auto_scaler_profile {
     balance_similar_node_groups = true


### PR DESCRIPTION
## Description

Check that nodepool names are not too long. Stripping the `np` prefix to give more space to users to define names.

Fixes #64 
