### PR TITLE
Allow users to use a custom name for their virtual network

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,14 @@ Type: `map(string)`
 
 Default: `null`
 
+### <a name="input_virtual_network_name"></a> [virtual\_network\_name](#input\_virtual\_network\_name)
+
+Description: (Optional) The Virtual Network for node IPs in the Kubernetes cluster. Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `"vnet"`
+
 ## Outputs
 
 The following outputs are exported:

--- a/main.tf
+++ b/main.tf
@@ -273,7 +273,7 @@ module "avm_res_network_virtualnetwork" {
 
   address_space       = var.node_cidr != null ? [var.node_cidr] : ["10.31.0.0/16"]
   location            = var.location
-  name                = "vnet"
+  name                = var.virtual_network_name
   resource_group_name = var.resource_group_name
   subnets = {
     "subnet" = {

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "monitor_metrics" {
 EOT
 }
 
+variable "virtual_network_name" {
+  type        = string
+  default     = "vnet"
+  description = "(Optional) The Virtual Network for node IPs in the Kubernetes cluster. Changing this forces a new resource to be created."
+}
+
 variable "node_cidr" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -93,12 +93,6 @@ variable "monitor_metrics" {
 EOT
 }
 
-variable "virtual_network_name" {
-  type        = string
-  default     = "vnet"
-  description = "(Optional) The Virtual Network for node IPs in the Kubernetes cluster. Changing this forces a new resource to be created."
-}
-
 variable "node_cidr" {
   type        = string
   default     = null
@@ -197,4 +191,10 @@ variable "tags" {
   type        = map(string)
   default     = null
   description = "(Optional) Tags of the resource."
+}
+
+variable "virtual_network_name" {
+  type        = string
+  default     = "vnet"
+  description = "(Optional) The Virtual Network for node IPs in the Kubernetes cluster. Changing this forces a new resource to be created."
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #83
Closes #83
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->


- [ x ] Azure Verified Module updates:
    - [ x ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.

# Checklist

- [ x ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
