### PR TITLE
Update AKS version to 1.30

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -59,7 +59,7 @@ resource "azurerm_resource_group" "this" {
 # with a data source.
 module "test" {
   source              = "../../"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.30"
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -53,7 +53,7 @@ resource "azurerm_resource_group" "this" {
 # with a data source.
 module "test" {
   source              = "../../"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.30"
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name

--- a/examples/with_availability_zone/README.md
+++ b/examples/with_availability_zone/README.md
@@ -47,7 +47,7 @@ resource "azurerm_user_assigned_identity" "this" {
 # with a data source.
 module "test" {
   source              = "../../"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.30"
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name
@@ -73,7 +73,7 @@ module "test" {
     workload = {
       name                 = "workloadworkload" #Long name to test the truncate to 12 characters
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 10
       min_count            = 2
       os_sku               = "Ubuntu"
@@ -83,7 +83,7 @@ module "test" {
     ingress = {
       name                 = "ingress"
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 4
       min_count            = 2
       os_sku               = "Ubuntu"

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_user_assigned_identity" "this" {
 # with a data source.
 module "test" {
   source              = "../../"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.30"
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name
@@ -67,7 +67,7 @@ module "test" {
     workload = {
       name                 = "workloadworkload" #Long name to test the truncate to 12 characters
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 10
       min_count            = 2
       os_sku               = "Ubuntu"
@@ -77,7 +77,7 @@ module "test" {
     ingress = {
       name                 = "ingress"
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 4
       min_count            = 2
       os_sku               = "Ubuntu"

--- a/examples/without_availability_zone/README.md
+++ b/examples/without_availability_zone/README.md
@@ -46,7 +46,7 @@ resource "azurerm_user_assigned_identity" "this" {
 # with a data source.
 module "test" {
   source              = "../../"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.30"
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name
@@ -72,7 +72,7 @@ module "test" {
     workload = {
       name                 = "workload"
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 110
       min_count            = 2
       os_sku               = "AzureLinux"
@@ -81,7 +81,7 @@ module "test" {
     ingress = {
       name                 = "ingress"
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 4
       min_count            = 2
       os_sku               = "AzureLinux"

--- a/examples/without_availability_zone/main.tf
+++ b/examples/without_availability_zone/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_user_assigned_identity" "this" {
 # with a data source.
 module "test" {
   source              = "../../"
-  kubernetes_version  = "1.28"
+  kubernetes_version  = "1.30"
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = module.naming.kubernetes_cluster.name_unique
   resource_group_name = azurerm_resource_group.this.name
@@ -66,7 +66,7 @@ module "test" {
     workload = {
       name                 = "workload"
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 110
       min_count            = 2
       os_sku               = "AzureLinux"
@@ -75,7 +75,7 @@ module "test" {
     ingress = {
       name                 = "ingress"
       vm_size              = "Standard_D2d_v5"
-      orchestrator_version = "1.28"
+      orchestrator_version = "1.30"
       max_count            = 4
       min_count            = 2
       os_sku               = "AzureLinux"


### PR DESCRIPTION
## Description

We need to bump the AKS tests to 1.30 before 1.31 goes GA, because 1.28 will go end of life