### PR TITLE
Make default SKU configurable and add ingress labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+### <a name="input_default_node_pool_vm_sku"></a> [default\_node\_pool\_vm\_sku](#input\_default\_node\_pool\_vm\_sku)
+
+Description: The VM SKU to use for the default node pool. A minimum of three nodes of 8 vCPUs or two nodes of at least 16 vCPUs is recommended. Do not use SKUs with less than 4 CPUs and 4Gb of memory.
+
+Type: `string`
+
+Default: `"Standard_D4d_v5"`
+
 ### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
 
 Description: This variable controls whether or not telemetry is enabled for the module.  

--- a/examples/with_availability_zone/README.md
+++ b/examples/with_availability_zone/README.md
@@ -93,7 +93,9 @@ module "test" {
       os_sku               = "Ubuntu"
       mode                 = "User"
       os_disk_size_gb      = 128
-
+      labels = {
+        "ingress" = "true"
+      }
     }
   }
 }

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -87,7 +87,9 @@ module "test" {
       os_sku               = "Ubuntu"
       mode                 = "User"
       os_disk_size_gb      = 128
-
+      labels = {
+        "ingress" = "true"
+      }
     }
   }
 }

--- a/examples/without_availability_zone/README.md
+++ b/examples/without_availability_zone/README.md
@@ -91,6 +91,9 @@ module "test" {
       min_count            = 2
       os_sku               = "AzureLinux"
       mode                 = "User"
+      labels = {
+        "ingress" = "true"
+      }
     }
   }
 }

--- a/examples/without_availability_zone/main.tf
+++ b/examples/without_availability_zone/main.tf
@@ -85,6 +85,9 @@ module "test" {
       min_count            = 2
       os_sku               = "AzureLinux"
       mode                 = "User"
+      labels = {
+        "ingress" = "true"
+      }
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
   default_node_pool_available_zones = setsubtract(local.zones, local.restricted_zones)
   filtered_vms = [
     for sku in data.azapi_resource_list.example.output.value :
-    sku if(sku.resourceType == "virtualMachines" && sku.name == "Standard_D4d_v5")
+    sku if(sku.resourceType == "virtualMachines" && sku.name == var.default_node_pool_vm_sku)
   ]
   restricted_zones = try(local.filtered_vms[0].restrictions[0].restrictionInfo.zones, [])
   zones            = local.filtered_vms[0].locationInfo[0].zones

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "azurerm_kubernetes_cluster" "this" {
 
   default_node_pool {
     name                    = "agentpool"
-    vm_size                 = "Standard_D4d_v5"
+    vm_size                 = var.default_node_pool_vm_sku
     auto_scaling_enabled    = true
     host_encryption_enabled = true
     max_count               = 9

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,12 @@ variable "agents_tags" {
   description = "(Optional) A mapping of tags to assign to the Node Pool."
 }
 
+variable "default_node_pool_vm_sku" {
+  type        = string
+  default     = "Standard_D4d_v5"
+  description = "The VM SKU to use for the default node pool. A minimum of three nodes of 8 vCPUs or two nodes of at least 16 vCPUs is recommended. Do not use SKUs with less than 4 CPUs and 4Gb of memory."
+}
+
 variable "enable_telemetry" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Description

Make possible to configure the SKU of the default nodepool.

In the examples add a label ingress=true to the nodepools that is needed for Pod placement when installing ingress Pods

