### PR TITLE
ACR config was ignored because of wrong indentation

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -75,11 +75,11 @@ module "test" {
     resource_group_name = azurerm_resource_group.this.name
     node_subnet_id      = module.avm_res_network_virtualnetwork.subnets["subnet"].resource_id
     pod_cidr            = "192.168.0.0/16"
-    acr = {
-      name                          = module.naming.container_registry.name_unique
-      subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
-      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
-    }
+  }
+  acr = {
+    name                          = module.naming.container_registry.name_unique
+    subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
+    private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
   }
 }
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -69,11 +69,11 @@ module "test" {
     resource_group_name = azurerm_resource_group.this.name
     node_subnet_id      = module.avm_res_network_virtualnetwork.subnets["subnet"].resource_id
     pod_cidr            = "192.168.0.0/16"
-    acr = {
-      name                          = module.naming.container_registry.name_unique
-      subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
-      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
-    }
+  }
+  acr = {
+    name                          = module.naming.container_registry.name_unique
+    subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
+    private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
   }
 }
 

--- a/examples/with_availability_zone/README.md
+++ b/examples/with_availability_zone/README.md
@@ -59,11 +59,11 @@ module "test" {
     resource_group_name = azurerm_resource_group.this.name
     node_subnet_id      = module.avm_res_network_virtualnetwork.subnets["subnet"].resource_id
     pod_cidr            = "192.168.0.0/16"
-    acr = {
-      name                          = module.naming.container_registry.name_unique
-      subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
-      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
-    }
+  }
+  acr = {
+    name                          = module.naming.container_registry.name_unique
+    subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
+    private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
   }
   managed_identities = {
     user_assigned_resource_ids = [

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -53,11 +53,11 @@ module "test" {
     resource_group_name = azurerm_resource_group.this.name
     node_subnet_id      = module.avm_res_network_virtualnetwork.subnets["subnet"].resource_id
     pod_cidr            = "192.168.0.0/16"
-    acr = {
-      name                          = module.naming.container_registry.name_unique
-      subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
-      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
-    }
+  }
+  acr = {
+    name                          = module.naming.container_registry.name_unique
+    subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
+    private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
   }
   managed_identities = {
     user_assigned_resource_ids = [

--- a/examples/without_availability_zone/README.md
+++ b/examples/without_availability_zone/README.md
@@ -58,11 +58,11 @@ module "test" {
     resource_group_name = azurerm_resource_group.this.name
     node_subnet_id      = module.avm_res_network_virtualnetwork.subnets["subnet"].resource_id
     pod_cidr            = "192.168.0.0/16"
-    acr = {
-      name                          = module.naming.container_registry.name_unique
-      subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
-      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
-    }
+  }
+  acr = {
+    name                          = module.naming.container_registry.name_unique
+    subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
+    private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
   }
   managed_identities = {
     user_assigned_resource_ids = [

--- a/examples/without_availability_zone/main.tf
+++ b/examples/without_availability_zone/main.tf
@@ -52,11 +52,11 @@ module "test" {
     resource_group_name = azurerm_resource_group.this.name
     node_subnet_id      = module.avm_res_network_virtualnetwork.subnets["subnet"].resource_id
     pod_cidr            = "192.168.0.0/16"
-    acr = {
-      name                          = module.naming.container_registry.name_unique
-      subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
-      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
-    }
+  }
+  acr = {
+    name                          = module.naming.container_registry.name_unique
+    subnet_resource_id            = module.avm_res_network_virtualnetwork.subnets["private_link_subnet"].resource_id
+    private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
   }
   managed_identities = {
     user_assigned_resource_ids = [


### PR DESCRIPTION
## Description

ACR config was ignored because of wrong indentation

This was a regression from PR #124

