### PR TITLE
Add os_disk_type, outbound_type, and update output.resource_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ map(object({
   max\_count            = (Optional) The maximum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be greater than or equal to `min_count`.  
   min\_count            = (Optional) The minimum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be less than or equal to `max_count`.  
   os\_sku               = (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`or `AzureLinux`. If not specified, the default is `AzureLinux`. Changing this forces a new resource to be created.  
+  os\_disk\_type         = (Optional) Specifies the type of disk which should be used for the Operating System. Possible values include: `Managed`or `Ephemeral`. If not specified, the default is `Managed`. Changing this forces a new resource to be created.  
   mode                 = (Optional) Should this Node Pool be used for System or User resources? Possible values are `System` and `User`. Defaults to `User`.  
   os\_disk\_size\_gb      = (Optional) The Agent Operating System disk size in GB. Changing this forces a new resource to be created.  
   tags                 = (Optional) A mapping of tags to assign to the resource. At this time there's a bug in the AKS API where Tags for a Node Pool are not stored in the correct case - you [may wish to use Terraform's `ignore_changes` functionality to ignore changes to the casing](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changess) until this is fixed in the AKS API.  
@@ -263,6 +264,7 @@ Example input:
       max_count            = 4
       min_count            = 2
       os_sku               = "Ubuntu"
+      os_disk_type         = "Ephemeral"
       mode                 = "User"
     }
   }
@@ -279,6 +281,7 @@ map(object({
     max_count       = optional(number)
     min_count       = optional(number)
     os_sku          = optional(string, "AzureLinux")
+    os_disk_type    = optional(string, "Managed")
     mode            = optional(string)
     os_disk_size_gb = optional(number, null)
     tags            = optional(map(string), {})
@@ -296,6 +299,14 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type)
+
+Description: (Optional) Specifies the OS Disk Type used by the agent pool. Possible values include: `Managed` or `Ephemeral`. If not specified, the default is `Managed`.Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `"Managed"`
+
 ### <a name="input_os_sku"></a> [os\_sku](#input\_os\_sku)
 
 Description: (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu` or `AzureLinux`. If not specified, the default is `AzureLinux`.Changing this forces a new resource to be created.
@@ -303,6 +314,14 @@ Description: (Optional) Specifies the OS SKU used by the agent pool. Possible va
 Type: `string`
 
 Default: `"AzureLinux"`
+
+### <a name="input_outbound_type"></a> [outbound\_type](#input\_outbound\_type)
+
+Description: (Optional) Specifies the outbound type that will be used for cluster outbound (egress) routing. Possible values include: `loadBalancer`,`userDefinedRouting`,`managedNATGateway`,`userAssignedNATGateway`. If not specified, the default is `loadBalancer`.Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `"loadBalancer"`
 
 ### <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id)
 

--- a/examples/with_availability_zone/README.md
+++ b/examples/with_availability_zone/README.md
@@ -71,8 +71,8 @@ module "test" {
     ]
   }
   rbac_aad_tenant_id = data.azurerm_client_config.current.tenant_id
-
-  location = "East US 2" # Hardcoded because we have to test in a region with availability zones
+  os_disk_type       = "Ephemeral"
+  location           = "East US 2" # Hardcoded because we have to test in a region with availability zones
   node_pools = {
     workload = {
       name                 = "workloadworkload" #Long name to test the truncate to 12 characters

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -65,8 +65,8 @@ module "test" {
     ]
   }
   rbac_aad_tenant_id = data.azurerm_client_config.current.tenant_id
-  os_disk_type = "Ephemeral"
-  location = "East US 2" # Hardcoded because we have to test in a region with availability zones
+  os_disk_type       = "Ephemeral"
+  location           = "East US 2" # Hardcoded because we have to test in a region with availability zones
   node_pools = {
     workload = {
       name                 = "workloadworkload" #Long name to test the truncate to 12 characters

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -65,7 +65,7 @@ module "test" {
     ]
   }
   rbac_aad_tenant_id = data.azurerm_client_config.current.tenant_id
-
+  os_disk_type = "Ephemeral"
   location = "East US 2" # Hardcoded because we have to test in a region with availability zones
   node_pools = {
     workload = {

--- a/locals.tf
+++ b/locals.tf
@@ -51,6 +51,7 @@ locals {
         tags                 = pool.tags
         labels               = pool.labels
         os_sku               = pool.os_sku
+        os_disk_type         = pool.os_disk_type
         mode                 = pool.mode
         os_disk_size_gb      = pool.os_disk_size_gb
         zone                 = [zone]

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,7 @@ resource "azurerm_kubernetes_cluster" "this" {
     node_labels             = var.node_labels
     orchestrator_version    = var.orchestrator_version
     os_sku                  = var.os_sku
+    os_disk_type            = var.os_disk_type
     tags                    = merge(var.tags, var.agents_tags)
     vnet_subnet_id          = var.network.node_subnet_id
     zones                   = local.default_node_pool_available_zones
@@ -122,6 +123,7 @@ resource "azurerm_kubernetes_cluster" "this" {
     network_policy      = var.network_policy
     pod_cidr            = var.network.pod_cidr
     service_cidr        = var.network.service_cidr
+    outbound_type       = var.outbound_type
   }
   oms_agent {
     log_analytics_workspace_id      = azurerm_log_analytics_workspace.this.id
@@ -276,6 +278,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   node_labels           = each.value.labels
   orchestrator_version  = each.value.orchestrator_version
   os_disk_size_gb       = each.value.os_disk_size_gb
+  os_disk_type          = each.value.os_disk_type
   os_sku                = each.value.os_sku
   tags                  = each.value.tags
   vnet_subnet_id        = var.network.node_subnet_id

--- a/main.tf
+++ b/main.tf
@@ -81,8 +81,8 @@ resource "azurerm_kubernetes_cluster" "this" {
     min_count               = 3
     node_labels             = var.node_labels
     orchestrator_version    = var.orchestrator_version
-    os_sku                  = var.os_sku
     os_disk_type            = var.os_disk_type
+    os_sku                  = var.os_sku
     tags                    = merge(var.tags, var.agents_tags)
     vnet_subnet_id          = var.network.node_subnet_id
     zones                   = local.default_node_pool_available_zones
@@ -121,9 +121,9 @@ resource "azurerm_kubernetes_cluster" "this" {
     network_data_plane  = var.network_policy == "cilium" ? "cilium" : null
     network_plugin_mode = "overlay"
     network_policy      = var.network_policy
+    outbound_type       = var.outbound_type
     pod_cidr            = var.network.pod_cidr
     service_cidr        = var.network.service_cidr
-    outbound_type       = var.outbound_type
   }
   oms_agent {
     log_analytics_workspace_id      = azurerm_log_analytics_workspace.this.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -148,7 +148,7 @@ output "private_fqdn" {
 
 output "resource_id" {
   description = "The Kubernetes Managed Cluster ID."
-  value       = azurerm_kubernetes_cluster.this.id
+  value       = azapi_update_resource.aks_cluster_post_create.id
 }
 
 output "web_app_routing_web_app_routing_identity_client_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -221,7 +221,6 @@ variable "os_disk_type" {
   }
 }
 
-
 variable "os_sku" {
   type        = string
   default     = "AzureLinux"

--- a/variables.tf
+++ b/variables.tf
@@ -148,6 +148,7 @@ variable "node_pools" {
     max_count       = optional(number)
     min_count       = optional(number)
     os_sku          = optional(string, "AzureLinux")
+    os_disk_type    = optional(string, "Managed")
     mode            = optional(string)
     os_disk_size_gb = optional(number, null)
     tags            = optional(map(string), {})
@@ -163,6 +164,7 @@ map(object({
   max_count            = (Optional) The maximum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be greater than or equal to `min_count`.
   min_count            = (Optional) The minimum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be less than or equal to `max_count`.
   os_sku               = (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`or `AzureLinux`. If not specified, the default is `AzureLinux`. Changing this forces a new resource to be created.
+  os_disk_type         = (Optional) Specifies the type of disk which should be used for the Operating System. Possible values include: `Managed`or `Ephemeral`. If not specified, the default is `Managed`. Changing this forces a new resource to be created.
   mode                 = (Optional) Should this Node Pool be used for System or User resources? Possible values are `System` and `User`. Defaults to `User`.
   os_disk_size_gb      = (Optional) The Agent Operating System disk size in GB. Changing this forces a new resource to be created.
   tags                 = (Optional) A mapping of tags to assign to the resource. At this time there's a bug in the AKS API where Tags for a Node Pool are not stored in the correct case - you [may wish to use Terraform's `ignore_changes` functionality to ignore changes to the casing](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changess) until this is fixed in the AKS API.
@@ -188,6 +190,7 @@ Example input:
       max_count            = 4
       min_count            = 2
       os_sku               = "Ubuntu"
+      os_disk_type         = "Ephemeral"
       mode                 = "User"
     }
   }
@@ -207,6 +210,18 @@ variable "orchestrator_version" {
   description = "Specify which Kubernetes release to use. Specify only minor version, such as '1.28'."
 }
 
+variable "os_disk_type" {
+  type        = string
+  default     = "Managed"
+  description = "(Optional) Specifies the OS Disk Type used by the agent pool. Possible values include: `Managed` or `Ephemeral`. If not specified, the default is `Managed`.Changing this forces a new resource to be created."
+
+  validation {
+    condition     = can(regex("^(Managed|Ephemeral)$", var.os_disk_type))
+    error_message = "os_disk_type must be either Managed or Ephemeral"
+  }
+}
+
+
 variable "os_sku" {
   type        = string
   default     = "AzureLinux"
@@ -215,6 +230,17 @@ variable "os_sku" {
   validation {
     condition     = can(regex("^(Ubuntu|AzureLinux)$", var.os_sku))
     error_message = "os_sku must be either Ubuntu or AzureLinux"
+  }
+}
+
+variable "outbound_type" {
+  type        = string
+  default     = "loadBalancer"
+  description = "(Optional) Specifies the outbound type that will be used for cluster outbound (egress) routing. Possible values include: `loadBalancer`,`userDefinedRouting`,`managedNATGateway`,`userAssignedNATGateway`. If not specified, the default is `loadBalancer`.Changing this forces a new resource to be created."
+
+  validation {
+    condition     = can(regex("^(loadBalancer|userDefinedRouting|managedNATGateway|userAssignedNATGateway)$", var.outbound_type))
+    error_message = "outbound_type must be  loadBalancer, userDefinedRouting, managedNATGateway, userAssignedNATGateway"
   }
 }
 


### PR DESCRIPTION
## Description

Adding ability to specify the os_disk_type and outbound_type. 

Also updated the output.resource_id. This is because if you are deploying any resources that changes/updates AKS, such as "azurerm_kubernetes_cluster_extension" and setting a module dependancies, using depends = [module.aks.resource_id], you will have a conflict. This is because the output will become available once the AKS cluster is deployed within the module but within the module there is a azapi_update_resource. As a result, the desire is to have the output.resource_id available once the azapi_update_resource is finished. 



## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
