### PR TITLE
fix: remove unused mandatory inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,9 @@ Type:
 
 ```hcl
 object({
-    name                = string
-    resource_group_name = string
-    node_subnet_id      = string
-    pod_cidr            = string
-    service_cidr        = optional(string)
+    node_subnet_id = string
+    pod_cidr       = string
+    service_cidr   = optional(string)
   })
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,9 +16,9 @@ variable "name" {
 
 variable "network" {
   type = object({
-    node_subnet_id      = string
-    pod_cidr            = string
-    service_cidr        = optional(string)
+    node_subnet_id = string
+    pod_cidr       = string
+    service_cidr   = optional(string)
   })
   description = "Values for the networking configuration of the AKS cluster"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,8 +16,6 @@ variable "name" {
 
 variable "network" {
   type = object({
-    name                = string
-    resource_group_name = string
     node_subnet_id      = string
     pod_cidr            = string
     service_cidr        = optional(string)


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

The `name` and `resource_group_name` on the `network` variable are not used anywhere in the code. Removing them makes the module easier to use. 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
