### PR TITLE
change `azurerm_kubernetes_cluster_node_pool` `for_each` collection to map with fixed key

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following resources are used by this module:
 
 - [azapi_update_resource.aks_cluster_post_create](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) (resource)
-- [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) (resource)
+- [azurerm_kubernetes_cluster_node_pool.extra_pool](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) (resource)
 - [azurerm_log_analytics_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
 - [azurerm_log_analytics_workspace_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace_table) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)

--- a/examples/with_availability_zone/README.md
+++ b/examples/with_availability_zone/README.md
@@ -49,6 +49,8 @@ data "azurerm_client_config" "current" {}
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {
+  # source  = "Azure/avm-ptn-aks-production/azurerm"
+  # version = "0.5.0"
   source = "../../"
 
   location = "East US 2" # Hardcoded because we have to test in a region with availability zones
@@ -71,7 +73,7 @@ module "test" {
     ]
   }
   node_pools = {
-    workload = {
+    workloadworkload = {
       name                 = "workloadworkload" #Long name to test the truncate to 12 characters
       vm_size              = "Standard_D2d_v5"
       orchestrator_version = "1.30"

--- a/examples/with_availability_zone/main.tf
+++ b/examples/with_availability_zone/main.tf
@@ -43,6 +43,8 @@ data "azurerm_client_config" "current" {}
 # Leaving location as `null` will cause the module to use the resource group location
 # with a data source.
 module "test" {
+  # source  = "Azure/avm-ptn-aks-production/azurerm"
+  # version = "0.5.0"
   source = "../../"
 
   location = "East US 2" # Hardcoded because we have to test in a region with availability zones
@@ -65,7 +67,7 @@ module "test" {
     ]
   }
   node_pools = {
-    workload = {
+    workloadworkload = {
       name                 = "workloadworkload" #Long name to test the truncate to 12 characters
       vm_size              = "Standard_D2d_v5"
       orchestrator_version = "1.30"

--- a/locals.tf
+++ b/locals.tf
@@ -38,10 +38,27 @@ locals {
 
 
 locals {
+  node_pool_map = {
+    for pool in local.node_pools : pool.key => {
+      name                 = pool.name
+      vm_size              = pool.vm_size
+      orchestrator_version = pool.orchestrator_version
+      max_count            = pool.max_count
+      min_count            = pool.min_count
+      tags                 = pool.tags
+      labels               = pool.labels
+      os_sku               = pool.os_sku
+      os_disk_type         = pool.os_disk_type
+      mode                 = pool.mode
+      os_disk_size_gb      = pool.os_disk_size_gb
+      zone                 = pool.zone
+    }
+  }
   # Flatten a list of var.node_pools and zones
   node_pools = flatten([
-    for pool in local.zonetagged_node_pools : [
+    for key, pool in local.zonetagged_node_pools : [
       for zone in pool.zones : {
+        key = "${substr(key, 0, 10)}${zone}"
         # concatenate name and zone trim to 12 characters
         name                 = "${substr(pool.name, 0, 10)}${zone}"
         vm_size              = pool.vm_size

--- a/main.tf
+++ b/main.tf
@@ -265,11 +265,13 @@ resource "azurerm_management_lock" "this" {
   notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
 }
 
+moved {
+  from = azurerm_kubernetes_cluster_node_pool.this
+  to   = azurerm_kubernetes_cluster_node_pool.extra_pool
+}
 
-resource "azurerm_kubernetes_cluster_node_pool" "this" {
-  for_each = tomap({
-    for pool in local.node_pools : pool.name => pool
-  })
+resource "azurerm_kubernetes_cluster_node_pool" "extra_pool" {
+  for_each = local.node_pool_map
 
   kubernetes_cluster_id = azurerm_kubernetes_cluster.this.id
   name                  = each.value.name
@@ -295,6 +297,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
     }
   }
 }
+
 
 # Data source for the current subscription
 data "azurerm_subscription" "current" {}


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #178
Closes #456
-->

Fixes #178

The original `azurerm_kubernetes_cluster_node_pool` depends on pool's `name`, which could contain values known after apply, like random string. This pr use `var.node_pools`'s key as node pool's key's prefix. To avoid potential destructions of node pools, please ensure that `var.node_pools''s key equals to node's `name`'s value.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
