### PR TITLE
feat: optional zone redundancy for node pools, configurable default node pool and per-pool upgrade settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ Type: `map(string)`
 
 Default: `{}`
 
+### <a name="input_default_node_pool"></a> [default\_node\_pool](#input\_default\_node\_pool)
+
+Description: (Optional) Default (system) node pool configuration. The defaults reproduce the values that were previously hardcoded.
+
+- `auto_scaling_enabled` - (Optional) Enable the cluster autoscaler for the default node pool. Defaults to `true`.
+- `max_count` - (Optional) Maximum number of nodes the default node pool scales up to. Defaults to `9`.
+- `max_pods` - (Optional) Maximum number of pods that can run on each node. Defaults to `110`.
+- `min_count` - (Optional) Minimum number of nodes the default node pool scales down to. Defaults to `3`.
+- `only_critical_addons_enabled` - (Optional) Taint the default node pool with `CriticalAddonsOnly` so only system pods are scheduled on it. Defaults to `false`.
+
+Type:
+
+```hcl
+object({
+    auto_scaling_enabled         = optional(bool, true)
+    max_count                    = optional(number, 9)
+    max_pods                     = optional(number, 110)
+    min_count                    = optional(number, 3)
+    only_critical_addons_enabled = optional(bool, false)
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_default_node_pool_vm_sku"></a> [default\_node\_pool\_vm\_sku](#input\_default\_node\_pool\_vm\_sku)
 
 Description: The VM SKU to use for the default node pool. A minimum of three nodes of 8 vCPUs or two nodes of at least 16 vCPUs is recommended. Do not use SKUs with less than 4 CPUs and 4Gb of memory.
@@ -286,6 +310,11 @@ map(object({
     os_disk_size_gb = optional(number, null)
     tags            = optional(map(string), {})
     labels          = optional(map(string), {})
+    upgrade_settings = optional(object({
+      drain_timeout_in_minutes = optional(number, 30)
+      max_surge                = optional(string, "10%")
+      max_unavailable          = optional(string, "0")
+    }), null)
   }))
 ```
 
@@ -370,6 +399,14 @@ Description: (Optional) Tags of the resource.
 Type: `map(string)`
 
 Default: `null`
+
+### <a name="input_zone_redundancy_enabled"></a> [zone\_redundancy\_enabled](#input\_zone\_redundancy\_enabled)
+
+Description: (Optional) Enable zone redundancy for the AKS cluster nodes. Defaults to true, which creates one node pool per available zone for each entry in `var.node_pools`. If set to false, a single node pool is created per entry, spanning every available zone. Note that `min_count` and `max_count` then apply once to that pool rather than once per zone, so the same input yields fewer nodes.
+
+Type: `bool`
+
+Default: `true`
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -25,14 +25,26 @@ locals {
       sku if(sku.resourceType == "virtualMachines" && sku.name == pool.vm_size)
     ]
   }
-  my_node_pool_zones_by_pool = {
-    for pool_name, pool in var.node_pools : pool_name => setsubtract(
+  # Zones each pool's own VM size can be placed in, with the zones that are
+  # restricted for this subscription removed. Sorted so the result is stable
+  # regardless of the order the SKU API returns them in.
+  node_pool_available_zones = {
+    for pool_name, pool in var.node_pools : pool_name => sort(setsubtract(
       local.filtered_vms_by_node_pool[pool_name][0].locationInfo[0].zones,
       try(local.filtered_vms_by_node_pool[pool_name][0].restrictions[0].restrictionInfo.zones, [])
+    ))
+  }
+  # One node pool is created per group of zones below. With zone redundancy every
+  # zone gets a group, and therefore a dedicated pool; without it all zones form a
+  # single group, so one pool spans them and AKS spreads its nodes across them.
+  # A pool whose VM size has no available zone gets no group, and so no pool.
+  node_pool_zone_groups = {
+    for pool_name, zones in local.node_pool_available_zones : pool_name => (
+      var.zone_redundancy_enabled ? [for zone in zones : [zone]] : (length(zones) == 0 ? [] : [zones])
     )
   }
   zonetagged_node_pools = {
-    for pool_name, pool in var.node_pools : pool_name => merge(pool, { zones = local.my_node_pool_zones_by_pool[pool_name] })
+    for pool_name, pool in var.node_pools : pool_name => merge(pool, { zone_groups = local.node_pool_zone_groups[pool_name] })
   }
 }
 
@@ -40,9 +52,10 @@ locals {
   # Flatten a list of var.node_pools and zones
   node_pools = flatten([
     for pool in local.zonetagged_node_pools : [
-      for zone in pool.zones : {
-        # concatenate name and zone trim to 12 characters
-        name                 = "${substr(pool.name, 0, 10)}${zone}"
+      for zones in pool.zone_groups : {
+        # one pool per zone needs the zone concatenated to keep the names unique; a single pool
+        # spanning every zone keeps the name as given. Both are trimmed to the 12 character limit.
+        name                 = var.zone_redundancy_enabled ? "${substr(pool.name, 0, 10)}${zones[0]}" : substr(pool.name, 0, 12)
         vm_size              = pool.vm_size
         orchestrator_version = pool.orchestrator_version
         max_count            = pool.max_count
@@ -53,7 +66,8 @@ locals {
         os_disk_type         = pool.os_disk_type
         mode                 = pool.mode
         os_disk_size_gb      = pool.os_disk_size_gb
-        zone                 = [zone]
+        upgrade_settings     = pool.upgrade_settings
+        zone                 = zones
       }
     ]
   ])

--- a/main.tf
+++ b/main.tf
@@ -73,20 +73,22 @@ resource "azurerm_kubernetes_cluster" "this" {
   workload_identity_enabled         = true
 
   default_node_pool {
-    name                    = "agentpool"
-    auto_scaling_enabled    = true
-    host_encryption_enabled = true
-    max_count               = 9
-    max_pods                = 110
-    min_count               = 3
-    node_labels             = var.node_labels
-    orchestrator_version    = var.orchestrator_version
-    os_disk_type            = var.os_disk_type
-    os_sku                  = var.os_sku
-    tags                    = merge(var.tags, var.agents_tags)
-    vm_size                 = var.default_node_pool_vm_sku
-    vnet_subnet_id          = var.network.node_subnet_id
-    zones                   = local.default_node_pool_available_zones
+    name                         = "agentpool"
+    auto_scaling_enabled         = var.default_node_pool.auto_scaling_enabled
+    host_encryption_enabled      = true
+    max_count                    = var.default_node_pool.max_count
+    max_pods                     = var.default_node_pool.max_pods
+    min_count                    = var.default_node_pool.min_count
+    node_labels                  = var.node_labels
+    only_critical_addons_enabled = var.default_node_pool.only_critical_addons_enabled
+    orchestrator_version         = var.orchestrator_version
+    os_disk_type                 = var.os_disk_type
+    os_sku                       = var.os_sku
+    tags                         = merge(var.tags, var.agents_tags)
+    temporary_name_for_rotation  = "agentpooltmp"
+    vm_size                      = var.default_node_pool_vm_sku
+    vnet_subnet_id               = var.network.node_subnet_id
+    zones                        = local.default_node_pool_available_zones
 
     upgrade_settings {
       max_surge = "10%"
@@ -141,7 +143,8 @@ resource "azurerm_kubernetes_cluster" "this" {
 
   lifecycle {
     ignore_changes = [
-      kubernetes_version
+      kubernetes_version,
+      default_node_pool[0].upgrade_settings
     ]
 
     precondition {
@@ -260,7 +263,7 @@ resource "azurerm_monitor_diagnostic_setting" "aks" {
     category = "csi-snapshot-controller"
   }
 
-  metric {
+  enabled_metric {
     category = "AllMetrics"
   }
 }
@@ -295,12 +298,27 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   vnet_subnet_id        = var.network.node_subnet_id
   zones                 = each.value.zone
 
+  dynamic "upgrade_settings" {
+    for_each = each.value.upgrade_settings == null ? [] : [each.value.upgrade_settings]
+
+    content {
+      drain_timeout_in_minutes = upgrade_settings.value.drain_timeout_in_minutes
+      max_surge                = upgrade_settings.value.max_surge
+      max_unavailable          = upgrade_settings.value.max_unavailable
+    }
+  }
+
   lifecycle {
+    ignore_changes = [
+      upgrade_settings
+    ]
+
     precondition {
       condition     = can(regex("^[a-z][a-z0-9]{0,11}$", each.value.name))
       error_message = "The name must begin with a lowercase letter, contain only lowercase letters and numbers, and be between 1 and 12 characters in length."
     }
   }
+
   depends_on = [azapi_update_resource.aks_cluster_post_create]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,11 @@ variable "node_pools" {
     os_disk_size_gb = optional(number, null)
     tags            = optional(map(string), {})
     labels          = optional(map(string), {})
+    upgrade_settings = optional(object({
+      drain_timeout_in_minutes = optional(number, 30)
+      max_surge                = optional(string, "10%")
+      max_unavailable          = optional(string, "0")
+    }), null)
   }))
   default     = {}
   description = <<-EOT
@@ -204,6 +209,13 @@ EOT
   }
 }
 
+variable "zone_redundancy_enabled" {
+  type        = bool
+  default     = true
+  description = "(Optional) Enable zone redundancy for the AKS cluster nodes. Defaults to true, which creates one node pool per available zone for each entry in `var.node_pools`. If set to false, a single node pool is created per entry, spanning every available zone. Note that `min_count` and `max_count` then apply once to that pool rather than once per zone, so the same input yields fewer nodes."
+  nullable    = false
+}
+
 variable "orchestrator_version" {
   type        = string
   default     = null
@@ -230,6 +242,26 @@ variable "os_sku" {
     condition     = can(regex("^(Ubuntu|AzureLinux)$", var.os_sku))
     error_message = "os_sku must be either Ubuntu or AzureLinux"
   }
+}
+
+variable "default_node_pool" {
+  type = object({
+    auto_scaling_enabled         = optional(bool, true)
+    max_count                    = optional(number, 9)
+    max_pods                     = optional(number, 110)
+    min_count                    = optional(number, 3)
+    only_critical_addons_enabled = optional(bool, false)
+  })
+  default     = {}
+  description = <<-EOT
+(Optional) Default (system) node pool configuration. The defaults reproduce the values that were previously hardcoded.
+
+- `auto_scaling_enabled` - (Optional) Enable the cluster autoscaler for the default node pool. Defaults to `true`.
+- `max_count` - (Optional) Maximum number of nodes the default node pool scales up to. Defaults to `9`.
+- `max_pods` - (Optional) Maximum number of pods that can run on each node. Defaults to `110`.
+- `min_count` - (Optional) Minimum number of nodes the default node pool scales down to. Defaults to `3`.
+- `only_critical_addons_enabled` - (Optional) Taint the default node pool with `CriticalAddonsOnly` so only system pods are scheduled on it. Defaults to `false`.
+EOT
 }
 
 variable "outbound_type" {


### PR DESCRIPTION
This adds three optional inputs: `zone_redundancy_enabled`, `default_node_pool`, and a per-pool `upgrade_settings` block. It also brings the diagnostic settings and node pool upgrade settings in line with the azurerm v4 provider. Every new default reproduces the module's current behaviour, so existing callers see no functional change when they upgrade.

### 1. Optional zone redundancy for user node pools (`variables.tf`, `locals.tf`)

New input:

```hcl
variable "zone_redundancy_enabled" {
  type     = bool
  default  = true
  nullable = false
}
```

Right now `local.node_pools` fans every entry of `var.node_pools` out into one node pool per availability zone that the pool's VM size supports. For production that is what you want: a dedicated pool per zone lets the cluster autoscaler scale each zone on its own, and a zone outage stays contained to one pool. The cost is a 3x floor on node count, which is hard to justify on a non-production cluster.

Setting `zone_redundancy_enabled = false` creates a single node pool per entry instead, spanning every zone available to it, and leaves AKS to distribute the nodes across those zones. Leaving it at `true` keeps today's behaviour.

The implementation makes the fan-out explicit instead of inferring it from the zone list. `local.node_pool_available_zones` works out which zones each pool can actually use, taking them from that pool's own `vm_size` and subtracting the zones restricted for the subscription. The result is sorted, so it does not depend on the order the SKU API happens to return them in. `local.node_pool_zone_groups` then turns that into the groups of zones to build pools for: one single-zone group per zone when redundancy is on, one group holding every zone when it is off. Each group becomes exactly one node pool.

The zone suffix only goes on the name when redundancy is on, since that is what keeps the names unique. A single pool keeps the name as given. Both get trimmed to the 12 character limit that `azurerm_kubernetes_cluster_node_pool` enforces.

A pool whose VM size has no available zone at all gets no group, so it produces no node pool. That covers regions without availability zones, like the one in `examples/without_availability_zone`, and it matches what the module does today.

The cluster's own `default_node_pool` already works the way the `false` path does: one pool with `zones = local.default_node_pool_available_zones`. It needed no change, and the two are now consistent with each other.

### 2. Configurable default node pool (`variables.tf`, `main.tf`)

The cluster's `default_node_pool` had `min_count`, `max_count`, `max_pods` and autoscaling hardcoded. A new object input drives them now, with defaults set to the values they replace, plus `only_critical_addons_enabled` for callers who want the system pool tainted `CriticalAddonsOnly`:

```hcl
variable "default_node_pool" {
  type = object({
    auto_scaling_enabled         = optional(bool, true)   # was hardcoded true
    max_count                    = optional(number, 9)    # was hardcoded 9
    max_pods                     = optional(number, 110)  # was hardcoded 110
    min_count                    = optional(number, 3)    # was hardcoded 3
    only_critical_addons_enabled = optional(bool, false)
  })
  default = {}
}
```

The block also sets `temporary_name_for_rotation = "agentpooltmp"`. Several default node pool properties cannot be changed in place, `only_critical_addons_enabled` and `max_pods` among them, and without a temporary name the provider fails the update instead of rotating the pool through a surge pool.

### 3. Per-pool upgrade settings, and upgrade settings drift (`variables.tf`, `main.tf`, `locals.tf`)

Entries in `var.node_pools` take an optional `upgrade_settings` block with `drain_timeout_in_minutes`, `max_surge` and `max_unavailable`. It renders as a `dynamic` block and defaults to `null`, so pools that do not set it are unchanged.

Both the cluster's `default_node_pool[0].upgrade_settings` and the user node pools' `upgrade_settings` now sit in `ignore_changes`. AKS normalises `max_surge` server-side, so the configured value reads back differently and left a non-empty plan on every run.

### 4. azurerm v4 alignment (`main.tf`)

`metric` becomes `enabled_metric` in `azurerm_monitor_diagnostic_setting.aks`. The `metric` block is deprecated in azurerm v4 and due for removal in v5.

## Backwards compatibility

Callers who set none of the new inputs see no change in behaviour. `zone_redundancy_enabled` defaults to `true`, `upgrade_settings` to `null`, and every `default_node_pool` attribute to the value it replaced.

Two things for reviewers running this against live state:

- The `metric` to `enabled_metric` switch shows up as an in-place update to the diagnostic setting on the first plan after upgrading. The cluster itself is untouched.
- Flipping an existing deployment to `zone_redundancy_enabled = false` is destructive by design. The node pool names change (`workload1` becomes `workload`), so `for_each` rekeys, the old pools are destroyed and one replacement is created. Expect node drain, and schedule it as maintenance rather than a routine apply.

## Validation

- `terraform validate` and `terraform fmt -check` are clean. `tflint` is clean against its default ruleset; the AVM ruleset runs in CI.
- `README.md` regenerated with `terraform-docs -c .terraform-docs.yml .`
- I exercised the `local.node_pools` expressions against stubbed Azure SKU data with the flag set both ways. The cases covered were a SKU offering all three zones (returned unsorted), a SKU with one zone restricted for the subscription, a 12 character pool name, and a SKU with every zone restricted. With redundancy off, each pool spans the zones its own SKU offers, so the restricted SKU gets `["2","3"]` rather than `["1","2","3"]`. With redundancy on, the output is identical to the pre-change module. Generated names satisfy the module's own `^[a-z][a-z0-9]{0,11}$` precondition in both modes, and a pool with no available zone produces no node pool either way.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks


---

Fixes #230

<!-- gh-aw-workflow-id: issue-triage -->